### PR TITLE
Add intel on Wiz, Permiso, Vanta, Grafana and DataTheorem and Orca

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -510,4 +510,34 @@
   "owner": "Data Theorem",
   "description": "Data Theorem",
   "id": "835257243705"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "976280145156",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "727815099310",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "553950354547",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "135916806842",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "463932680998",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
+}, {
+  "owner": "Orca Security",
+  "description": "Orca Security",
+  "id": "784971140435",
+  "source": "https://orcasecurity.force.com/s/article/Orca-Scanner-Accounts-for-AWS-Trusted-Entities?topic=Onboarding&subtopic=AWS&article=Orca-Scanner-Accounts-for-AWS-Trusted-Entities"
 }]

--- a/accounts.json
+++ b/accounts.json
@@ -489,4 +489,25 @@
   "source": "https://insightvm.help.rapid7.com/docs/aws-connect-to-cloud-configuration-assessment",
   "description": "Rapid7 InsightVM Cloud Configuration",
   "id": "336818582268"
+}, {
+  "owner": "Wiz",
+  "description": "Wiz",
+  "id": "197171649850"
+  }, {
+  "owner": "Permiso",
+  "description": "Permiso",
+  "id": "940313271035"
+}, {
+  "owner": "Vanta",
+  "description": "Vanta",
+  "id": "956993596390"
+}, {
+  "owner": "Grafana",
+  "description": "Grafana CloudWatch Integration",
+  "id": "008923505280",
+  "source": "https://grafana.com/docs/grafana-cloud/integrations/integrations/integration-cloudwatch/"
+}, {
+  "owner": "Data Theorem",
+  "description": "Data Theorem",
+  "id": "835257243705"
 }]


### PR DESCRIPTION
Some of these do not have docs that we can provide as a source. They
were observed from AWS IAM Role trust policies upon configuring the
vendor.